### PR TITLE
Match only port number in start_nrepl

### DIFF
--- a/quick
+++ b/quick
@@ -80,7 +80,7 @@ def start_nrepl(port=None, toplevel=False):
     port = None
     while port is None and line is not None:
         print(line, end='', file=sys.stderr)
-        match = re.match(r"^nREPL server started on port ([0-9]+) on host ([^ ]+)$", line.rstrip())
+        match = re.match(r"port ([0-9]+)", line.rstrip())
         if match is not None:
             port = int(match.group(1))
             break

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(name="quick-clojure",
-      version='0.11',
+      version='0.12',
       packages=find_packages(),
       # metadata for upload to PyPI
       author="Ben Booth",


### PR DESCRIPTION
Per benwbooth/quick-clojure#3, the nREPL STDOUT format has changed and the pattern would never match, resulting in `quick start` blocking.